### PR TITLE
WIP: Fixes for gup's render sizes and spike attack

### DIFF
--- a/src/main/java/net/msrandom/featuresandcreatures/client/renderer/entity/GupRenderer.java
+++ b/src/main/java/net/msrandom/featuresandcreatures/client/renderer/entity/GupRenderer.java
@@ -22,22 +22,19 @@ public class GupRenderer extends GeoEntityRenderer<Gup> {
 
     @Override
     public void render(Gup entity, float entityYaw, float partialTicks, PoseStack stack, MultiBufferSource bufferIn, int packedLightIn) {
-        stack.translate(0.0D, 0.001F, 0.0D);
 
+        float gupModelBlockHeight = 1.75f;
+        float scalingFactor = 1 / gupModelBlockHeight;
         switch (entity.getSize()) {
-            case 1 -> {
-                float f1 = (float) entity.getSize() / 1.01F;
-                stack.scale(f1, f1, f1);
-            }
             case 2 -> {
-                float f2 = (float) entity.getSize() / 1.433333F;
-                stack.scale(f2, f2, f2);
+                scalingFactor *= 2.5f;
             }
             case 3 -> {
-                float f3 = (float) entity.getSize() / 1.75F;
-                stack.scale(f3, f3, f3);
+                scalingFactor *= 5.0f;
             }
         }
+        stack.scale(scalingFactor, scalingFactor, scalingFactor);
+
         super.render(entity, entityYaw, partialTicks, stack, bufferIn, packedLightIn);
     }
 }

--- a/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
+++ b/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
@@ -247,12 +247,13 @@ public class Gup extends PathfinderMob implements IAnimatable {
         data.addAnimationController(new AnimationController<>(this, "controller", 0, this::predicate));
     }
 
-    public void doDamage() {
-        AABB axisalignedbb = (new AABB(this.blockPosition())).inflate(1.5F).expandTowards(0.0D, 2.0D, 0.0D);
+    public void doSpikeAttack() {
+        float attackRange = 1.5F;
+        AABB axisalignedbb = this.getDimensions(this.getPose()).makeBoundingBox(0, 0, 0).inflate(attackRange).move(this.position());
         List<LivingEntity> list = this.level.getEntitiesOfClass(LivingEntity.class, axisalignedbb);
         for (LivingEntity le : list) {
-            if (le instanceof Gup) return;
-            le.hurt(DamageSource.GENERIC, (float) this.getAttribute(Attributes.ATTACK_DAMAGE).getValue());
+            if (le instanceof Gup) continue;
+            le.hurt(DamageSource.mobAttack(this), (float) this.getAttribute(Attributes.ATTACK_DAMAGE).getValue());
         }
     }
 
@@ -508,7 +509,7 @@ public class Gup extends PathfinderMob implements IAnimatable {
                 this.gup.lookAt(livingentity, 10.0F, 10.0F);
                 gup.setAttacking(true);
                 if (gup.getAttackTimer() <= 1) {
-                    gup.doDamage();
+                    gup.doSpikeAttack();
                 }
             }
             ((Gup.GupMoveControl) this.gup.getMoveControl()).setDirection(this.gup.getYRot(), true);
@@ -578,8 +579,8 @@ public class Gup extends PathfinderMob implements IAnimatable {
             if (entityDistance <= attackRange && isTimeToAttack()) {
                 resetAttackCooldown();
                 gup.setAttacking(true);
-                if (this.gup.getAttackTimer() <= 30) {
-                    gup.doHurtTarget(livingEntity);
+                if (this.gup.getAttackTimer() >= 30) {
+                    gup.doSpikeAttack();
                     gup.setAttacking(false);
                 }
             }
@@ -604,7 +605,7 @@ public class Gup extends PathfinderMob implements IAnimatable {
 
         @Override
         protected double getAttackReachSqr(LivingEntity entity) {
-            return 4F + entity.getBbWidth();
+            return this.gup.getBbWidth() * this.gup.getBbWidth();
         }
     }
 }

--- a/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
+++ b/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
@@ -219,7 +219,27 @@ public class Gup extends PathfinderMob implements IAnimatable {
     }
 
     public EntityDimensions getDimensions(Pose pose) {
-        return super.getDimensions(pose).scale(0.9F * (float) this.getSize());
+        if (pose == Pose.DYING) {
+            return super.getDimensions(pose);
+        }
+
+        float gupModelBlockHeight = 1.75f;
+        float scalingFactor = 1;
+        // Scale the gup's height to 1 block on the server thread only to avoid the hitbox having a different size when rendering
+        if (!this.level.isClientSide) {
+            scalingFactor /= gupModelBlockHeight;
+        }
+        
+        switch (this.getSize()) {
+            case 2 -> {
+                scalingFactor *= 2.5;
+            }
+            case 3 -> {
+                scalingFactor *= 5.0;
+            }
+        }
+
+        return super.getDimensions(pose).scale(scalingFactor);
     }
 
     @Override

--- a/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
+++ b/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
@@ -224,22 +224,25 @@ public class Gup extends PathfinderMob implements IAnimatable {
         }
 
         float gupModelBlockHeight = 1.75f;
-        float scalingFactor = 1;
+        float heightScalingFactor = 1;
+        float widthScalingFactor = 1;
         // Scale the gup's height to 1 block on the server thread only to avoid the hitbox having a different size when rendering
         if (!this.level.isClientSide) {
-            scalingFactor /= gupModelBlockHeight;
+            heightScalingFactor /= gupModelBlockHeight;
         }
         
         switch (this.getSize()) {
             case 2 -> {
-                scalingFactor *= 2.5;
+                heightScalingFactor *= 2.5;
+                widthScalingFactor *= 2.5;
             }
             case 3 -> {
-                scalingFactor *= 5.0;
+                heightScalingFactor *= 5.0;
+                widthScalingFactor *= 5.0;
             }
         }
 
-        return super.getDimensions(pose).scale(scalingFactor);
+        return super.getDimensions(pose).scale(widthScalingFactor, heightScalingFactor);
     }
 
     @Override

--- a/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
+++ b/src/main/java/net/msrandom/featuresandcreatures/common/entity/Gup.java
@@ -576,13 +576,13 @@ public class Gup extends PathfinderMob implements IAnimatable {
         protected void checkAndPerformAttack(@NotNull LivingEntity livingEntity, double entityDistance) {
             double attackRange = getAttackReachSqr(livingEntity);
             if (livingEntity instanceof Player player && player.getAbilities().instabuild) return;
-            if (entityDistance <= attackRange && isTimeToAttack()) {
+            if (!gup.isAttacking() && entityDistance <= attackRange && isTimeToAttack()) {
                 resetAttackCooldown();
                 gup.setAttacking(true);
-                if (this.gup.getAttackTimer() >= 30) {
-                    gup.doSpikeAttack();
-                    gup.setAttacking(false);
-                }
+            }
+            if (gup.getAttackTimer() >= 30) {
+                gup.doSpikeAttack();
+                gup.setAttacking(false);
             }
         }
 

--- a/src/main/java/net/msrandom/featuresandcreatures/core/FnCEntities.java
+++ b/src/main/java/net/msrandom/featuresandcreatures/core/FnCEntities.java
@@ -22,7 +22,7 @@ public class FnCEntities {
     public static final RegistryObject<EntityType<Jackalope>> JACKALOPE = createEntity("jackalope", EntityType.Builder.of(Jackalope::new, MobCategory.CREATURE).sized(1F, 0.8F));
     public static final RegistryObject<EntityType<Sabertooth>> SABERTOOTH = createEntity("sabertooth", EntityType.Builder.of(Sabertooth::new, MobCategory.CREATURE).sized(1.2F, 1.3F));
     public static final RegistryObject<EntityType<BlackForestSpirit>> BLACK_FOREST_SPIRIT = createEntity("black_forest_spirit", EntityType.Builder.of(BlackForestSpirit::new, MobCategory.CREATURE).sized(0.7F, 2f));
-    public static final RegistryObject<EntityType<Gup>> GUP = createEntity("gup", EntityType.Builder.of(Gup::new, MobCategory.CREATURE).sized(2.625F, 2f));
+    public static final RegistryObject<EntityType<Gup>> GUP = createEntity("gup", EntityType.Builder.of(Gup::new, MobCategory.CREATURE).sized(2.625F, 1.75F));
     public static final RegistryObject<EntityType<BrimstoneGolem>> BRIMSTONE_GOLEM = createEntity("brimstone_golem", EntityType.Builder.of(BrimstoneGolem::new, MobCategory.CREATURE).sized(2.6F, 4f));
     public static final RegistryObject<EntityType<ShulkrenYoungling>> SHULKREN_YOUNGLING = createEntity("shulkren_youngling", EntityType.Builder.of(ShulkrenYoungling::new, MobCategory.CREATURE).sized(0.8F, 1.65f));
     public static final RegistryObject<EntityType<BFSAttack>> BFS_ATTACK = createEntity("bfs_attack", EntityType.Builder.<BFSAttack>of((p_37391_, p_37392_) -> new BFSAttack(p_37392_), MobCategory.MISC).sized(0.4F, 0.4f));


### PR DESCRIPTION
This is almost ready to merge, there's just a few minor issues that I'm stuck on:

- The gup's width according to the server isn't scaling properly. The hitbox size is fine on the client side (i.e.: when rendering) but just not on the server side. 
- Not sure what range the gup should start attacking from. For now I've set it up so they'll try their spike attack when its target gets within gup's width^2. The spike attack will only damage mobs within 1.5 blocks of the gup.